### PR TITLE
Fix "assert" for usage with Node 22

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ import fs from 'fs-extra';
 import path from 'path';
 import { fileURLToPath } from 'url';
 
-import packageJson from './package.json' assert { type: 'json' };
+import packageJson from './package.json' with { type: 'json' };
 
 const program = new Command();
 const __filename = fileURLToPath(import.meta.url);


### PR DESCRIPTION
The assert syntax has been replaced by with, and it's currently only shipped by Chrome and Node.js. Other browsers will only ship the with syntax